### PR TITLE
Fix mapping imports and viewer syntax

### DIFF
--- a/baselines/pyplanners/graph.py
+++ b/baselines/pyplanners/graph.py
@@ -1,4 +1,8 @@
-from collections import namedtuple, Mapping
+from collections import namedtuple
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python <3.3
+    from collections import Mapping
 from heapq import heappush, heappop
 
 

--- a/baselines/pyplanners/multi_rrt.py
+++ b/baselines/pyplanners/multi_rrt.py
@@ -1,4 +1,7 @@
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python <3.3
+    from collections import Mapping
 from random import random
 
 from .rrt import TreeNode, configs

--- a/baselines/pyplanners/prm.py
+++ b/baselines/pyplanners/prm.py
@@ -1,4 +1,8 @@
-from collections import namedtuple, Mapping
+from collections import namedtuple
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python <3.3
+    from collections import Mapping
 from heapq import heappop, heappush
 import operator
 import time

--- a/baselines/pyplanners/star_roadmap.py
+++ b/baselines/pyplanners/star_roadmap.py
@@ -1,4 +1,7 @@
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python <3.3
+    from collections import Mapping
 
 class StarRoadmap(Mapping, object):
 

--- a/baselines/pyplanners/tkinter/viewer.py
+++ b/baselines/pyplanners/tkinter/viewer.py
@@ -173,7 +173,7 @@ def hex_from_8bit(rgb):
     return '#%02x%02x%02x' % tuple(rgb)
 
 def hex_from_rgb(rgb):
-    assert all(0. <= v <= 1.for v in rgb)
+    assert all(0. <= v <= 1. for v in rgb)
     return hex_from_8bit([int(v*(2**8-1)) for v in rgb])
 
 def spaced_colors(n, s=1, v=1):


### PR DESCRIPTION
## Summary
- ensure compatibility with Python 3.10+ by importing `Mapping` from `collections.abc`
- fix syntax typo in `hex_from_rgb`

## Testing
- `python -m py_compile $(git ls-files "baselines/pyplanners/*.py")`

------
https://chatgpt.com/codex/tasks/task_e_684ffe55fb3c8328a91e5ee180917ecd